### PR TITLE
docs: fix title suffix

### DIFF
--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { type DocsThemeConfig, Link } from 'nextra-theme-docs'
+import { useRouter } from 'next/router'
 import Logo from './components/logo'
 
 const config: DocsThemeConfig = {
@@ -30,6 +31,13 @@ const config: DocsThemeConfig = {
   },
   nextThemes: { defaultTheme: 'dark' },
   themeSwitch: { component: null },
+  useNextSeoProps: () => {
+    const { asPath } = useRouter()
+    if (asPath !== '/') {
+      return { titleTemplate: '%s - NextDevtools' }
+    }
+    return {}
+  },
 }
 
 export default config


### PR DESCRIPTION
Before, the title suffix was incorrect:
![image](https://github.com/xinyao27/next-devtools/assets/15154097/f05c00d5-bb3d-424e-a8a8-efe13e0346e0)

And this is after the fix:
![image](https://github.com/xinyao27/next-devtools/assets/15154097/c82c8e33-7d11-4de6-a93d-b4d408c89ace)